### PR TITLE
Token Bucket rate limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,20 @@
-/_build
-/cover
-/deps
-/doc
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-*.beam
-/config/*.secret.exs

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 20.1.7
+elixir 1.5.2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # ex_limiter
 Rate Limiter written in elixir with configurable backends
+
+Implements leaky bucket rate limiting ([wiki](https://en.wikipedia.org/wiki/Leaky_bucket)), which is superior to most naive approaches by handling bursts even around time windows.  You can define your own storage backend by implementing the `ExLimiter.Storage` behaviour, and configuring it with
+
+```elixir
+config :ex_limiter, :storage, MyStorage
+```
+
+usage once configured is:
+
+```elixir
+case ExLimiter.consume(bucket, 1, scale: 1000, limit: 5) do
+  {:ok, bucket} -> #do some work
+  {:error, :rate_limited} -> #fail
+end
+```
+
+Additionally, if you want to have multiple rate limiters with diverse backend implementations you can use the `ExLimiter.Base` macro, like so:
+
+```elixir
+defmodule MyLimiter do
+  use ExLimiter.Base, storage: MyStorage
+end
+```
+
+## ExLimiter.Plug
+
+ExLimiter also ships with a simple plug implementation.  Usage is
+
+```elixir
+plug ExLimiter.Plug, scale: 5000, limit: 20
+```
+
+You can also configure how the bucket is inferred from the given conn, how many tokens to consume and what limiter to use.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,7 @@
+use Mix.Config
+
+config :ex_limiter, :storage, ExLimiter.Storage.Memcache
+
+config :ex_limiter, ExLimiter.Plug,
+  limiter: ExLimiter,
+  fallback: ExLimiter.Plug

--- a/lib/ex_limiter.ex
+++ b/lib/ex_limiter.ex
@@ -1,0 +1,29 @@
+defmodule ExLimiter do
+  @moduledoc """
+  Configurable, leaky bucket rate limiting.  You can define your own storage backend by
+  implementing the `ExLimiter.Storage` behaviour, and configuring it with
+
+  ```
+  config :ex_limiter, :storage, MyStorage
+  ```
+
+  usage once configured is:
+
+  ```
+  case ExLimiter.consume(bucket, 1, scale: 1000, limit: 5) do
+    {:ok, bucket} -> #do some work
+    {:error, :rate_limited} -> #fail
+  end
+  ```
+
+  Additionally, if you want to have multiple rate limiters with diverse backend implementations,
+  you can use the `ExLimiter.Base` macro, like so:
+
+  ```
+  defmodule MyLimiter do
+    use ExLimiter.Base, storage: MyStorage
+  end
+  ```
+  """
+  use ExLimiter.Base, storage: Application.get_env(:ex_limiter, :storage)
+end

--- a/lib/ex_limiter/base.ex
+++ b/lib/ex_limiter/base.ex
@@ -1,0 +1,68 @@
+defmodule ExLimiter.Base do
+  @moduledoc """
+  Base module for arbitrary rate limiter implementations.  Usage is:
+
+  ```
+  defmodule MyLimiter do
+    use ExLimiterBase, storage: MyCustomStorage
+  end
+  ```
+  """
+  alias ExLimiter.{Bucket, Utils}
+
+  defmacro __using__(storage: storage) do
+    quote do
+      import ExLimiter.Base
+      @storage unquote(storage)
+
+      def remaining(%Bucket{value: val}, opts \\ []) do
+        limit = Keyword.get(opts, :limit, 10)
+        scale = Keyword.get(opts, :scale, 1000)
+
+        round((scale - val) / limit)
+      end
+
+      @doc """
+      Consumes `amount` from the rate limiter aliased by bucket. 
+      
+      `opts` params are:
+      * `:limit` - the maximum amount for the rate limiter (default 10)
+      * `:scale` - the duration under which `:limit` applies in milliseconds
+      """
+      @spec consume(bucket :: binary, amount :: integer, opts :: keyword) :: {:ok, Bucket.t} | {:error, :rate_limited}
+      def consume(bucket, amount \\ 1, opts \\ []),
+        do: consume(@storage, bucket, amount, opts)
+    end
+  end
+
+  @doc """
+  Delegate function for rate limiter implementations
+  """
+  @spec consume(atom, binary, integer, keyword) :: {:ok, Bucket.t} | {:error, :rate_limited}
+  def consume(storage, bucket, amount, opts) do
+    limit = Keyword.get(opts, :limit, 10)
+    scale = Keyword.get(opts, :scale, 1000)
+    
+    mult = scale / limit
+    incr = round(amount * mult)
+
+    case leak(storage, bucket) do
+      %Bucket{value: v} = b when v + incr <= scale -> storage.consume(b, incr)
+      _ -> {:error, :rate_limited}
+    end
+  end
+
+  defp leak(storage, bucket) do
+    %Bucket{value: value, last: time} = bucket = storage.fetch(%Bucket{key: bucket})
+    now    = Utils.now()
+    amount = max(value - (now - time), 0)
+    
+    # the latency of whatever storage should be sufficiently low that we can
+    # simply refetch and not miss too many drips (while catching a previous decrement)
+    storage.refresh(%{bucket | last: now, value: amount})
+    |> case do
+      {:ok, bucket} -> bucket
+      _ -> storage.fetch(bucket)
+    end
+  end
+end

--- a/lib/ex_limiter/bucket.ex
+++ b/lib/ex_limiter/bucket.ex
@@ -1,0 +1,18 @@
+defmodule ExLimiter.Bucket do
+  alias ExLimiter.Utils
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    key: nil,
+    value: 0,
+    last: nil,
+    version: %{}
+  ]
+
+  def new(key), do: %__MODULE__{key: key, last: Utils.now()}
+
+  def new(contents, key) when is_map(contents) do
+    struct(__MODULE__, Map.put(contents, :key, key))
+  end
+end

--- a/lib/ex_limiter/plug.ex
+++ b/lib/ex_limiter/plug.ex
@@ -1,0 +1,77 @@
+defmodule ExLimiter.Plug do
+  @moduledoc """
+  Plug for enforcing rate limits.  The usage should be something like
+
+  ```
+  plug ExLimiter.Plug, scale: 1000, limit: 5
+  ```
+
+  Additionally, you can pass in `:bucket` or `:consumes` as options, each of which
+  are 1-arity functions of a `Plug.Conn.t` which determine the bucket for the rate limit
+  and the amount to consume.  These default to the phoenix controller, action, and remote_ip
+  and 1 respectively.
+
+  Additionally, you can configure a custom limiter with
+
+  ```
+  config :ex_limiter, ExLimiter.Plug, limiter: MyLimiter
+  ```
+  
+  and you can also configure the rate limited response with
+
+  ```
+  config :ex_limiter, ExLimiter.Plug, fallback: MyFallback
+  ```
+
+  `MyFallback` needs to implement a function `render_error(conn, :rate_limited)`
+  """
+  import Plug.Conn
+
+  @limiter Application.get_env(:ex_limiter, __MODULE__)[:limiter]
+  @fallback Application.get_env(:ex_limiter, __MODULE__)[:fallback]
+
+  defmodule Config do
+    
+    defstruct [
+      scale: 1000,
+      limit: 10,
+      bucket: &ExLimiter.Plug.get_bucket/1,
+      consumes: nil
+    ]
+
+    def new(opts) do
+      contents =
+        Enum.into(opts, %{})
+        |> Map.put_new(:consumes, fn _ -> 1 end)
+
+      struct(__MODULE__, contents)
+    end
+  end
+
+  def get_bucket(%{private: %{phoenix_controller: contr, phoenix_action: ac}} = conn) do
+    "#{contr}.#{ac}.#{ip(conn)}"
+  end
+
+  def render_error(conn, :rate_limited) do
+    conn
+    |> resp(429, "Rate Limit Exceeded")
+    |> halt()
+  end
+
+  def init(opts), do: Config.new(opts)
+
+  def call(conn, %Config{bucket: bucket_fun, scale: scale, limit: limit, consumes: consume_fun}) do
+    bucket_fun.(conn)
+    |> @limiter.consume(consume_fun.(conn))
+    |> case do
+      {:ok, bucket} ->
+        conn
+        |> put_resp_header("x-ratelimit-limit", to_string(limit))
+        |> put_resp_header("x-ratelimit-window", to_string(scale))
+        |> put_resp_header("x-ratelimit-remaining", to_string(@limiter.remaining(bucket)))
+      {:error, :rate_limited} -> @fallback.render_error(conn, :rate_limited)
+    end
+  end
+
+  defp ip(conn), do: conn.remote_ip |> Tuple.to_list() |> Enum.join(".")
+end

--- a/lib/ex_limiter/storage.ex
+++ b/lib/ex_limiter/storage.ex
@@ -1,0 +1,21 @@
+defmodule ExLimiter.Storage do
+  alias ExLimiter.Bucket
+  @type response :: {:ok, Bucket.t} | {:error, any}
+  
+  @doc """
+  Fetch the current state of the given bucket
+  """
+  @callback fetch(bucket :: Bucket.t) :: Bucket.t
+
+  @doc """
+  Set the current state of the given bucket.  Specify hard if you want to
+  force a write
+  """
+  @callback refresh(bucket :: Bucket.t) :: response
+  @callback refresh(bucket :: Bucket.t, type :: :hard | :soft) :: response
+
+  @doc """
+  Consumes n elements from the bucket (atomically)
+  """
+  @callback consume(bucket :: Bucket.t, incr :: integer) :: {:ok, Bucket.t}
+end

--- a/lib/ex_limiter/storage/memcache.ex
+++ b/lib/ex_limiter/storage/memcache.ex
@@ -1,0 +1,62 @@
+defmodule ExLimiter.Storage.Memcache do
+  @moduledoc """
+  Token bucket backend written for memcache. Stores the last timestamp
+  and amount in separate keys, and utilizes memcache increments for consumption 
+  """
+  @behaviour ExLimiter.Storage
+  alias ExLimiter.{Bucket, Utils}
+
+  def fetch(%Bucket{key: key}) do
+    key_map = keys(key)
+
+    Map.keys(key_map) 
+    |> Memcachir.mget(cas: true)
+    |> case do
+      {:ok, result} -> from_memcached(result, key, key_map)
+      _ -> Bucket.new(key)
+    end
+  end
+
+  def refresh(%Bucket{key: key} = bucket, _type \\ :soft) do
+    keys(key)
+    |> Enum.map(&mset_command(&1, bucket))
+    |> Memcachir.mset_cas()
+    |> case do
+      {:ok, _} -> {:ok, bucket}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def consume(%Bucket{key: key} = bucket, inc) do
+    case Memcachir.incr("amount_#{key}", inc) do
+      {:ok, result} -> {:ok, %{bucket | value: result}}
+      _ -> {:ok, Bucket.new(key)}
+    end
+  end
+
+  defp keys(key), do: %{"amount_#{key}" => :value, "last_#{key}" => :last}
+
+  defp from_memcached(map, key, key_map) when is_map(map) do
+    key_map
+    |> Enum.reduce(%{version: %{}}, &reduce_memcached(&1, &2, map))
+    |> Enum.into(%{})
+    |> Bucket.new(key)
+  end
+
+  defp mset_command({key, bucket_key}, %Bucket{version: versions} = b) do 
+    value = Map.get(b, bucket_key) |> to_string()
+    {key, value, Map.get(versions, bucket_key, 0)}
+  end
+
+  defp reduce_memcached({key, bucket_key}, acc, map), do: add_result(acc, bucket_key, map[key])
+
+  defp add_result(%{version: versions} = acc, bucket_key, {val, cas}) do
+    acc
+    |> Map.put(bucket_key, Utils.parse_integer(val))
+    |> Map.put(:version, Map.put(versions, bucket_key, cas))
+  end
+  defp add_result(acc, bucket_key, _), do: add_result(acc, bucket_key, default(bucket_key))
+
+  defp default(:value), do: {0, 0}
+  defp default(:last), do: {Utils.now(), 0}
+end

--- a/lib/ex_limiter/utils.ex
+++ b/lib/ex_limiter/utils.ex
@@ -1,0 +1,8 @@
+defmodule ExLimiter.Utils do
+  def now(), do: :os.system_time(:millisecond)
+
+  def parse_integer(val) when is_binary(val), do: Integer.parse(val) |> parse_integer()
+  def parse_integer(val) when is_integer(val), do: val
+  def parse_integer(:error), do: :error
+  def parse_integer({val, _}), do: val
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,56 @@
+defmodule ExLimiter.Mixfile do
+  use Mix.Project
+
+  @version "0.1.0"
+
+  def project do
+    [
+      app: :ex_limiter,
+      version: @version,
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env),
+      deps: deps(),
+      description: description(),
+      package: package(),
+      docs: docs()
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp docs() do
+    [
+      main: "readme",
+      extras: ["README.md"],
+      source_ref: "v#{@version}",
+      source_url: "https://github.com/Frameio/ex_limiter"
+    ]
+  end
+
+  defp deps do
+    [
+      {:memcachir, git: "https://github.com/Frameio/memcachir.git"},
+      {:plug, "~> 1.4"},
+    ]
+  end
+
+  defp description() do
+    "Token bucket rate limiter written in elixir with configurable backends"
+  end
+
+  defp package() do
+    [
+      maintainers: ["Michael Guarino"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/Frameio/ex_limiter"}
+    ]
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,9 @@
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+  "elasticachex": {:hex, :elasticachex, "1.1.1", "52d759f65122655218cac363ec06ea7b756fc23f2a65f68ad0f10b1dfea57193", [], [{:socket, "~> 0.3", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
+  "libring": {:hex, :libring, "1.3.1", "b4273e25c6285f03a4b86d068aeee301be18a5aca3f0ca74f0c3a2f8b7d912b1", [], [], "hexpm"},
+  "memcachex": {:hex, :memcachex, "0.4.2", "c39d143e472bafe0e0cdd910137af1940a5b48abf837edb44308d5279076c5de", [], [{:connection, "~> 1.0.3", [hex: :connection, repo: "hexpm", optional: false]}, {:poison, "~> 2.1 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
+  "memcachir": {:git, "https://github.com/Frameio/memcachir.git", "e252aa41cf0638e4b6c40d4c4a3f6dcdebaf1051", []},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.1", "c62fe7623d035020cf989820b38490460e6903ab7eee29e234b7586e9b6c91d6", [], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [], [], "hexpm"}}

--- a/test/ex_limiter/plug_test.exs
+++ b/test/ex_limiter/plug_test.exs
@@ -1,0 +1,43 @@
+defmodule ExLimiter.PlugTest do
+  use ExUnit.Case
+  use Plug.Test
+  alias ExLimiter.TestUtils 
+
+  describe "#call/2" do
+    setup [:setup_limiter, :setup_conn]
+    
+    test "It will supply rate limiting headers if it passes", %{limiter: config, conn: conn} do
+      conn =
+        conn
+        |> ExLimiter.Plug.call(config)
+
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-limit"))
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-window"))
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-remaining"))
+    end
+
+    test "It will reject if the rate limit has been exceeded", %{limiter: config, conn: conn} do
+      conn =
+        %{conn | params: %{"count" => 11}}
+         |> ExLimiter.Plug.call(config)
+
+      assert conn.status == 429
+    end
+  end
+
+  defp setup_conn(_) do 
+    random =  TestUtils.rand_string()
+    conn =
+      conn(:get, "/")
+      |> merge_private(phoenix_controller: random, phoenix_action: random)
+
+    [conn: conn]
+  end
+
+  defp setup_limiter(_) do
+    [limiter: ExLimiter.Plug.Config.new(consumes: &consumes/1)]
+  end
+
+  defp consumes(%{params: %{"count" => count}}), do: count
+  defp consumes(_), do: 1
+end

--- a/test/ex_limiter_test.exs
+++ b/test/ex_limiter_test.exs
@@ -1,0 +1,21 @@
+defmodule ExLimiterTest do
+  use ExUnit.Case
+  alias ExLimiter.TestUtils
+  doctest ExLimiter
+
+  describe "#consume" do
+    test "it will rate limit" do
+      bucket_name = bucket()
+      {:ok, bucket} = ExLimiter.consume(bucket_name, 1)
+      
+      assert bucket.key == bucket_name
+      assert bucket.value >= 100
+
+      {:error, :rate_limited} = ExLimiter.consume(bucket_name, 10)
+    end
+  end
+
+  defp bucket() do
+    "test_bucket_#{TestUtils.rand_string()}"
+  end
+end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,0 +1,6 @@
+defmodule ExLimiter.TestUtils do
+  def rand_string() do
+    :crypto.strong_rand_bytes(8) 
+    |> Base.encode64()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION

Supports configurable storage backends (with a memcached based solution built-in), and implements
a plug for enforcing rate limits with additional configuration for bucket inference and the consumption
of the rate limit on the request.