### PR TITLE
Add `decorate` to Plug.Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+/tags
+/.elixir_ls/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.5.2
-erlang 20.1.7
+elixir 1.7.3
+erlang 21.0.3

--- a/lib/ex_limiter/plug.ex
+++ b/lib/ex_limiter/plug.ex
@@ -6,17 +6,29 @@ defmodule ExLimiter.Plug do
   plug ExLimiter.Plug, scale: 1000, limit: 5
   ```
 
-  Additionally, you can pass in `:bucket` or `:consumes` as options, each of which
-  are 1-arity functions of a `Plug.Conn.t` which determine the bucket for the rate limit
-  and the amount to consume.  These default to the phoenix controller, action, and remote_ip
-  and 1 respectively.
+  Additionally, you can pass the following options:
+
+  - `:bucket`, a 1-arity function of a `Plug.Conn.t` which determines
+    the bucket for the rate limit. Defaults to the phoenix controller,
+    action and remote_ip.
+
+  - `:consumes`, a 1-arity function of a `Plug.Conn.t` which determines
+    the amount to consume. Defaults to 1 respectively.
+
+  - `:decorate`, a 2-arity function which can return an updated conn
+    based on the outcome of the limiter call. The first argument is the
+    `Plug.Conn.t`, and the second can be:
+
+    - `{:ok, Bucket.t}`
+    - `{:rate_limited, binary}` Where the second element is the bucket
+      name that triggered the rate limit.
 
   Additionally, you can configure a custom limiter with
 
   ```
   config :ex_limiter, ExLimiter.Plug, limiter: MyLimiter
   ```
-  
+
   and you can also configure the rate limited response with
 
   ```
@@ -29,7 +41,7 @@ defmodule ExLimiter.Plug do
 
   @limiter Application.get_env(:ex_limiter, __MODULE__)[:limiter]
   @fallback Application.get_env(:ex_limiter, __MODULE__)[:fallback]
-  
+
 
   defmodule Config do
     @limit Application.get_env(:ex_limiter, ExLimiter.Plug)[:limit]
@@ -39,13 +51,15 @@ defmodule ExLimiter.Plug do
       scale: @scale,
       limit: @limit,
       bucket: &ExLimiter.Plug.get_bucket/1,
-      consumes: nil
+      consumes: nil,
+      decorate: nil,
     ]
 
     def new(opts) do
       contents =
         Enum.into(opts, %{})
         |> Map.put_new(:consumes, fn _ -> 1 end)
+        |> Map.put_new(:decorate, &ExLimiter.Plug.decorate/2)
 
       struct(__MODULE__, contents)
     end
@@ -61,20 +75,29 @@ defmodule ExLimiter.Plug do
     |> halt()
   end
 
+  @spec decorate(Plug.Conn.t, {:ok, Bucket.t} | {:rate_limited, bucket_name :: binary}) :: Plug.Conn.t
+  def decorate(conn, _), do: conn
+
   def init(opts), do: Config.new(opts)
 
-  def call(conn, %Config{bucket: bucket_fun, scale: scale, limit: limit, consumes: consume_fun}) do
-    bucket_fun.(conn)
+  def call(conn, %Config{bucket: bucket_fun, scale: scale, limit: limit, consumes: consume_fun, decorate: decorate_fun}) do
+    bucket_name = bucket_fun.(conn)
+
+    bucket_name
     |> @limiter.consume(consume_fun.(conn), scale: scale, limit: limit)
     |> case do
-      {:ok, bucket} ->
+      {:ok, bucket} = response ->
         remaining = @limiter.remaining(bucket, scale: scale, limit: limit)
 
         conn
         |> put_resp_header("x-ratelimit-limit", to_string(limit))
         |> put_resp_header("x-ratelimit-window", to_string(scale))
         |> put_resp_header("x-ratelimit-remaining", to_string(remaining))
-      {:error, :rate_limited} -> @fallback.render_error(conn, :rate_limited)
+        |> decorate_fun.(response)
+      {:error, :rate_limited} ->
+        conn
+        |> decorate_fun.({:rate_limited, bucket_name})
+        |> @fallback.render_error(:rate_limited)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLimiter.Mixfile do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.2.0"
 
   def project do
     [


### PR DESCRIPTION
Allows users to specify an arbitrary connection transformation function to take place after the rate-limit response is received