### PR TITLE
Remove memcache from auto starting in application

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Implements leaky bucket rate limiting ([wiki](https://en.wikipedia.org/wiki/Leak
 config :ex_limiter, :storage, MyStorage
 ```
 
+If you want to use Memcache as Storage. Add memcachir into your extra_applications in `mix.exs`
+
+```elixir
+def application do
+  [
+    extra_applications: [:memcachir]
+  ]
+end
+```
+
 usage once configured is:
 
 ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule ExLimiter.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      applications: []
     ]
   end
 


### PR DESCRIPTION
Hello. I love this simple library. Thank you for making it.

However, right now memcachir is in the dependencies which will start it's application and expect Memcache running. I have disabled this by specifying application as `[]` and update README to avoid confusion.