### PR TITLE
Implement pure elixir sharded backend.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,3 +7,6 @@ config :ex_limiter, ExLimiter.Plug,
   fallback: ExLimiter.Plug,
   limit: 10,
   scale: 1000
+
+config :ex_limiter, ExLimiter.Storage.PG2Shard,
+  shard_count: 20

--- a/lib/ex_limiter/storage/pg2_shard.ex
+++ b/lib/ex_limiter/storage/pg2_shard.ex
@@ -1,0 +1,55 @@
+defmodule ExLimiter.Storage.PG2Shard do
+  @moduledoc """
+  Implements the leaky bucket using a fleet of GenServers discoverable via a
+  pg2 group.
+
+  To configure the pool size, do:
+
+  ```
+  config :ex_limit, ExLimiter.Storage.PG2Shard,
+    shard_count: 20
+  ```
+
+  You must also include the shard supervisor in your app supervision tree, with
+  something like:
+
+  ```
+  ...
+  supervise(ExLimiter.Storage.PG2Shard.Supervisor, [])
+  ```
+  """
+  @behaviour ExLimiter.Storage
+  alias ExLimiter.Bucket
+  alias ExLimiter.Storage.PG2Shard.Router
+
+  def fetch(%Bucket{key: key}),
+    do: with_worker(key, &call(&1, {:fetch, key}))
+
+  def refresh(%Bucket{key: key} = bucket, _type \\ :soft),
+    do: {:ok, with_worker(key, &call(&1, {:set, bucket}))}
+
+  def delete(%Bucket{key: key} = bucket) do
+    with_worker(key, &call(&1, {:delete, key}))
+    bucket
+  end
+
+  def update(key, update_fun), do: with_worker(key, &call(&1, {:update, key, update_fun}))
+
+  def consume(%Bucket{key: key}, incr),
+    do: {:ok, with_worker(key, &call(&1, {:consume, key, incr}))}
+
+  defp call(pid, operation), do: GenServer.call(pid, operation)
+
+  defp with_worker(key, fun, fallback \\ nil) do
+    try do
+      case Router.shard(key) do
+        pid when is_pid(pid) -> fun.(pid)
+        _ -> fallback || %Bucket{key: key}
+      end
+    rescue
+      _error -> fallback || %Bucket{key: key}
+    catch
+      :exit, _ -> fallback || %Bucket{key: key}
+    end
+  end
+end

--- a/lib/ex_limiter/storage/pg2_shard/router.ex
+++ b/lib/ex_limiter/storage/pg2_shard/router.ex
@@ -1,0 +1,63 @@
+defmodule ExLimiter.Storage.PG2Shard.Router do
+  @moduledoc """
+  The routing mechanism for pg2 shard instances.  Currently
+  it resyncs (by calling `:pg2.get_members/1`) on nodeup/nodedown and
+  on a fixed poll interval.
+
+  Ideally we could implement a subscription mechanism in a process grouper like
+  swarm that could make this more snappy, but since the workers are statically
+  configured anyways, node connect/reconnect is actually a fairly reliable mechanism.
+  """
+  use GenServer
+
+  @process_group :ex_limiter_shards
+  @table_name :ex_limiter_router
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    :ok = :net_kernel.monitor_nodes(true, node_type: :all)
+    table = :ets.new(@table_name, [:set, :protected, :named_table, {:read_concurrency, true}])
+    :ets.insert(table, {:ring, shard_ring()})
+    send self(), :resync
+    {:ok, table}
+  end
+
+  def shard(key) do
+    case :ets.lookup(@table_name, :ring) do
+      [{:ring, ring}] -> HashRing.key_to_node(ring, key)
+      _ -> {:error, :noring}
+    end
+  end
+
+  def handle_info({:nodeup, _, _}, table) do
+    :ets.insert(table, {:ring, shard_ring()})
+    {:noreply, table}
+  end
+
+  def handle_info({:nodedown, _, _}, table) do
+    :ets.insert(table, {:ring, shard_ring()})
+    {:noreply, table}
+  end
+
+  def handle_info(:resync, table) do
+    resync()
+    :ets.insert(table, {:ring, shard_ring()})
+    {:noreply, table}
+  end
+
+  def shards() do
+    :pg2.create(@process_group)
+    :pg2.get_members(@process_group)
+    |> case do
+      {:error, _} -> []
+      members -> members
+    end
+  end
+
+  defp shard_ring(), do: HashRing.new() |> HashRing.add_nodes(shards())
+
+  defp resync(), do: Process.send_after(self(), :resync, 10_000)
+end

--- a/lib/ex_limiter/storage/pg2_shard/supervisor.ex
+++ b/lib/ex_limiter/storage/pg2_shard/supervisor.ex
@@ -1,0 +1,26 @@
+defmodule ExLimiter.Storage.PG2Shard.Supervisor do
+  @moduledoc """
+  Supervisor for the workers and shard router for the PG2Shard
+  backend.
+
+  This *must* be manually specified in your supervision tree for this
+  storage backend to work.
+  """
+  use Supervisor
+  alias ExLimiter.Storage.PG2Shard.{Worker, Router}
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    shards = Stream.cycle([{Worker, []}]) |> Enum.take(shard_count())
+    children = [{Router, []} | shards] |> Enum.reverse()
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp shard_count() do
+    Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)
+    |> Keyword.get(:shard_count, 0)
+  end
+end

--- a/lib/ex_limiter/storage/pg2_shard/supervisor.ex
+++ b/lib/ex_limiter/storage/pg2_shard/supervisor.ex
@@ -8,6 +8,7 @@ defmodule ExLimiter.Storage.PG2Shard.Supervisor do
   """
   use Supervisor
   alias ExLimiter.Storage.PG2Shard.{Worker, Router}
+  @telemetry Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)[:telemetry] || Worker
 
   def start_link() do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
@@ -16,8 +17,13 @@ defmodule ExLimiter.Storage.PG2Shard.Supervisor do
   def init(_) do
     shards = Stream.cycle([{Worker, []}]) |> Enum.take(shard_count())
     children = [{Router, []} | shards] |> Enum.reverse()
+
+    :telemetry.attach_many("exlimiter-metrics-handler", Worker.telemetry_events(), &@telemetry.handle_event/4, nil)
+
     Supervisor.init(children, strategy: :one_for_one)
   end
+
+  def handle_event(_, _, _, _), do: :ok
 
   defp shard_count() do
     Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)

--- a/lib/ex_limiter/storage/pg2_shard/worker.ex
+++ b/lib/ex_limiter/storage/pg2_shard/worker.ex
@@ -1,0 +1,106 @@
+defmodule ExLimiter.Storage.PG2Shard.Worker do
+  @moduledoc """
+  Simple Genserver for implementing the `ExLimiter.Storage` behavior for a set
+  of buckets.
+
+  Buckets are pruned after 10 minutes of inactivity, and buckets will be evicted
+  if a maximum threshold is reached.  To tune these values, use:
+
+  ```
+  config :ex_limiter, ExLimiter.Storage.PG2Shard,
+    max_size: 50_000,
+    eviction_count: 1000
+  ```
+  """
+  use GenServer
+  alias ExLimiter.Bucket
+  alias ExLimiter.Utils
+
+  @process_group :ex_limiter_shards
+  @expiry 10 * 60_000
+  @eviction_count Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)[:eviction_count] || 1000
+  @max_size Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)[:max_size] || 50_000
+  @monitor Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)[:monitor] || __MODULE__
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    :pg2.create(@process_group)
+    :pg2.join(@process_group, self())
+    prune()
+
+    {:ok, %{}}
+  end
+
+  def handle_call({:update, key, fun}, _from, buckets) do
+    bucket = fetch(buckets, key) |> fun.()
+    {:reply, bucket, upsert(buckets, key, bucket)}
+  end
+
+  def handle_call({:consume, key, amount}, _from, buckets) do
+    %{value: val} = bucket = fetch(buckets, key)
+    bucket = %{bucket | value: val + amount}
+    {:reply, bucket, upsert(buckets, key, bucket)}
+  end
+
+  def handle_call({:fetch, key}, _from, buckets) do
+    {:reply, fetch(buckets, key), buckets}
+  end
+
+  def handle_call({:set, %Bucket{key: k} = bucket}, _from, buckets) do
+    {:reply, bucket, upsert(buckets, k, bucket)}
+  end
+
+  def handle_call({:delete, key}, _from, buckets) do
+    {:reply, :ok, Map.delete(buckets, key)}
+  end
+
+  def handle_info(:prune, buckets) do
+    now = Utils.now()
+    buckets =
+      buckets
+      |> Enum.reject(fn
+        {_, %Bucket{last: last}} when now - @expiry > last -> true
+        _ -> false
+      end)
+      |> Enum.into(%{})
+
+    do_monitor(:buckets, buckets)
+    {:noreply, buckets}
+  end
+
+  def child_spec(_args) do
+    %{
+      id: make_ref(),
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
+  def monitor(_name, _buckets), do: :ok
+
+  defp upsert(buckets, key, bucket) when map_size(buckets) >= @max_size do
+    to_delete =
+      Enum.sort_by(buckets, fn {_, %{last: last}} -> last end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.take(@eviction_count)
+
+    do_monitor(:eviction, length(to_delete))
+    buckets
+    |> Map.drop(to_delete)
+    |> Map.put(key, bucket)
+  end
+  defp upsert(buckets, key, bucket), do: Map.put(buckets, key, bucket)
+
+  defp do_monitor(name, buckets), do: @monitor.monitor(name, buckets)
+
+  defp fetch(buckets, key) do
+    case buckets do
+      %{^key => bucket} -> bucket
+      _ -> Bucket.new(key)
+    end
+  end
+
+  defp prune(), do: Process.send_after(self(), :prune, 30_000)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLimiter.Mixfile do
   use Mix.Project
 
-  @version "1.2.2"
+  @version "1.3.0"
 
   def project do
     [
@@ -30,6 +30,7 @@ defmodule ExLimiter.Mixfile do
     [
       {:memcachir, "~> 3.2.0"},
       {:plug, "~> 1.4"},
+      {:libring, "~> 1.0"},
       {:ex_doc, "~> 0.19", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExLimiter.Mixfile do
     [
       app: :ex_limiter,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       start_permanent: Mix.env == :prod,
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),
@@ -28,7 +28,7 @@ defmodule ExLimiter.Mixfile do
 
   defp deps do
     [
-      {:memcachir, "~> 3.2.0"},
+      {:memcachir, "~> 3.2.0", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
       {:ex_doc, "~> 0.19", only: :dev}
@@ -42,6 +42,13 @@ defmodule ExLimiter.Mixfile do
       source_ref: "v#{@version}",
       source_url: "https://github.com/Frameio/ex_limiter"
     ]
+  end
+
+  defp run_in_test() do
+    case Mix.env do
+      :test -> []
+      _ -> [runtime: false]
+    end
   end
 
   defp description() do

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule ExLimiter.Mixfile do
       {:memcachir, "~> 3.2.0", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
+      {:telemetry, "~> 0.4.0"},
       {:ex_doc, "~> 0.19", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -13,4 +13,5 @@
   "plug": {:hex, :plug, "1.6.1", "c62fe7623d035020cf989820b38490460e6903ab7eee29e234b7586e9b6c91d6", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/ex_limiter/storage/pg2_shard_test.exs
+++ b/test/ex_limiter/storage/pg2_shard_test.exs
@@ -1,0 +1,58 @@
+defmodule ExLimiter.Storage.PG2ShardTest do
+  use ExUnit.Case, async: false
+  alias ExLimiter.Storage.PG2Shard
+  alias ExLimiter.PG2Limiter
+  alias ExLimiter.TestUtils
+
+  describe "#consume" do
+    test "it will rate limit" do
+      {:ok, pid} = PG2Shard.Supervisor.start_link()
+      bucket_name = bucket()
+      {:ok, bucket} = PG2Limiter.consume(bucket_name, 1)
+
+      assert bucket.key == bucket_name
+      assert bucket.value >= 100
+
+      {:ok, bucket} = PG2Limiter.consume(bucket_name, 5)
+
+      assert bucket.value >= 500
+
+      {:error, :rate_limited} = PG2Limiter.consume(bucket_name, 6)
+      Process.exit(pid, :kill)
+    end
+  end
+
+  describe "#delete" do
+    test "It will wipe a bucket" do
+      {:ok, pid} = PG2Shard.Supervisor.start_link()
+      bucket_name = bucket()
+
+      {:ok, bucket} = PG2Limiter.consume(bucket_name, 5)
+
+      assert bucket.value >= 500
+
+      PG2Limiter.delete(bucket_name)
+
+      {:ok, bucket} = PG2Limiter.consume(bucket_name, 1)
+
+      assert bucket.value <= 500
+      Process.exit(pid, :kill)
+    end
+  end
+
+  describe "#remaining" do
+    test "It will properly deconvert the remaining capacity in a bucket" do
+      {:ok, pid} = PG2Shard.Supervisor.start_link()
+      bucket_name = bucket()
+
+      {:ok, bucket} = PG2Limiter.consume(bucket_name, 5)
+
+      assert PG2Limiter.remaining(bucket) == 5
+      Process.exit(pid, :kill)
+    end
+  end
+
+  defp bucket() do
+    "test_bucket_#{TestUtils.rand_string()}"
+  end
+end

--- a/test/support/pg2_limiter.ex
+++ b/test/support/pg2_limiter.ex
@@ -1,0 +1,3 @@
+defmodule ExLimiter.PG2Limiter do
+  use ExLimiter.Base, storage: ExLimiter.Storage.PG2Shard
+end


### PR DESCRIPTION

Utilize pg2 to discover and shard requests to a fleet of genservers,
each which will perform the basic components of the leaky bucket algorithm.

This has two advantages over memcached:

1. No need to spam CAS operations to deal with concurrency safety
2. Can take advantage of erlang native rpcs which are quite efficient.

There is the slight drawback of sequential read/writes in genservers,
but that's frankly equivalent to what is found in a system like redis,
which would have been another backend choice, so eh.