### PR TITLE
Erlang/OTP 24 compatibility (:pg2 -> :pg)

### DIFF
--- a/lib/ex_limiter/storage/pg2_shard/router.ex
+++ b/lib/ex_limiter/storage/pg2_shard/router.ex
@@ -50,9 +50,7 @@ defmodule ExLimiter.Storage.PG2Shard.Router do
   end
 
   def shards() do
-    :pg2.create(@process_group)
-    :pg2.get_members(@process_group)
-    |> case do
+    case :pg.get_members(@process_group) do
       {:error, _} -> []
       members -> members
     end

--- a/lib/ex_limiter/storage/pg2_shard/router.ex
+++ b/lib/ex_limiter/storage/pg2_shard/router.ex
@@ -50,10 +50,7 @@ defmodule ExLimiter.Storage.PG2Shard.Router do
   end
 
   def shards() do
-    case :pg.get_members(@process_group) do
-      {:error, _} -> []
-      members -> members
-    end
+    :pg.get_members(@process_group)
   end
 
   defp regen(table) do

--- a/lib/ex_limiter/storage/pg2_shard/shutdown.ex
+++ b/lib/ex_limiter/storage/pg2_shard/shutdown.ex
@@ -21,7 +21,7 @@ defmodule ExLimiter.Storage.PG2Shard.Shutdown do
   end
 
   def terminate(_, pids) do
-    Enum.each(pids, &:pg2.leave(Worker.group(), &1))
+    Enum.each(pids, &:pg.leave(Worker.group(), &1))
     Node.list() |> Enum.each(&GenServer.cast({Router, &1}, :refresh))
     :timer.sleep(5_000)
   end

--- a/lib/ex_limiter/storage/pg2_shard/supervisor.ex
+++ b/lib/ex_limiter/storage/pg2_shard/supervisor.ex
@@ -19,6 +19,8 @@ defmodule ExLimiter.Storage.PG2Shard.Supervisor do
     children = [{Router, []} | shards] |> Enum.reverse()
 
     :telemetry.attach_many("exlimiter-metrics-handler", Worker.telemetry_events(), &@telemetry.handle_event/4, nil)
+    
+    {:ok, _pid} = :pg.start_link()
 
     Supervisor.init([{Pruner, []}, {Shutdown, []} | children], strategy: :one_for_one)
   end

--- a/lib/ex_limiter/storage/pg2_shard/supervisor.ex
+++ b/lib/ex_limiter/storage/pg2_shard/supervisor.ex
@@ -17,7 +17,7 @@ defmodule ExLimiter.Storage.PG2Shard.Supervisor do
   def init(_) do
     shards = Stream.cycle([{Worker, []}]) |> Enum.take(shard_count())
     children = [{Router, []} | shards] |> Enum.reverse()
-    children = [{:pg, []}, {Pruner, []}, {Shutdown, []} | children]
+    children = [pg_spec(), {Pruner, []}, {Shutdown, []} | children]
 
     :telemetry.attach_many("exlimiter-metrics-handler", Worker.telemetry_events(), &@telemetry.handle_event/4, nil)
 
@@ -25,6 +25,13 @@ defmodule ExLimiter.Storage.PG2Shard.Supervisor do
   end
 
   def handle_event(_, _, _, _), do: :ok
+
+  defp pg_spec do
+    %{
+      id: :pg,
+      start: {:pg, :start_link, []}
+    }
+  end
 
   defp shard_count() do
     Application.get_env(:ex_limiter, ExLimiter.Storage.PG2Shard)

--- a/lib/ex_limiter/storage/pg2_shard/worker.ex
+++ b/lib/ex_limiter/storage/pg2_shard/worker.ex
@@ -45,8 +45,7 @@ defmodule ExLimiter.Storage.PG2Shard.Worker do
   def group(), do: @process_group
 
   def init(_) do
-    :pg2.create(@process_group)
-    :pg2.join(@process_group, self())
+    :pg.join(@process_group, self())
 
     {:ok, Pruner.table()}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ExLimiter.Mixfile do
 
   defp deps do
     [
-      {:memcachir, "~> 3.3.1", run_in_test()},
+      {:memcachir, "~> 3.2.0", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
       {:telemetry, "~> 0.4.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ExLimiter.Mixfile do
 
   defp deps do
     [
-      {:memcachir, "~> 3.2.0", run_in_test()},
+      {:memcachir, "~> 3.3.1", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
       {:telemetry, "~> 0.4.0"},


### PR DESCRIPTION
With version 24, erlang's :pg2 module is removed, and replaced by :pg with similar functionality.  Creating groups is now neither necessary nor possible - all possible group names can be joined and checked for members at any time.  Checking a group with no members simply returns an empty list.