### PR TITLE
Updated dep telemetry to 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ExLimiter.Mixfile do
 
   defp deps do
     [
-      {:memcachir, "~> 3.2.0", run_in_test()},
+      {:memcachir, "~> 3.3.1", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
       {:telemetry, "~> 0.4 or ~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ExLimiter.Mixfile do
       {:memcachir, "~> 3.2.0", run_in_test()},
       {:plug, "~> 1.4"},
       {:libring, "~> 1.0"},
-      {:telemetry, "~> 0.4.0"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:ex2ms, "~> 1.5"},
       {:ex_doc, "~> 0.19", only: :dev}
     ]


### PR DESCRIPTION
Telemetry has moved on to 1.0, lots of other packages require 1.0. This should be able to use either.