### PR TITLE
[GRAPH-1018] Update `ExLimiter.Plug` to return rate limit headers on 429

### DIFF
--- a/lib/ex_limiter/plug.ex
+++ b/lib/ex_limiter/plug.ex
@@ -112,9 +112,9 @@ defmodule ExLimiter.Plug do
 
   defp put_rate_limit_headers(conn, limit, scale, remaining) do
     conn
-    |> put_resp_header("x-ratelimit-limit", to_string(limit))
-    |> put_resp_header("x-ratelimit-window", to_string(scale))
-    |> put_resp_header("x-ratelimit-remaining", to_string(remaining))
+    |> put_resp_header("x-ratelimit-limit", Integer.to_string(limit))
+    |> put_resp_header("x-ratelimit-window", Integer.to_string(scale))
+    |> put_resp_header("x-ratelimit-remaining", Integer.to_string(remaining))
   end
 
   defp ip(conn), do: conn.remote_ip |> Tuple.to_list() |> Enum.join(".")

--- a/lib/ex_limiter/plug.ex
+++ b/lib/ex_limiter/plug.ex
@@ -97,16 +97,24 @@ defmodule ExLimiter.Plug do
         remaining = @limiter.remaining(bucket, scale: scale, limit: limit)
 
         conn
-        |> put_resp_header("x-ratelimit-limit", to_string(limit))
-        |> put_resp_header("x-ratelimit-window", to_string(scale))
-        |> put_resp_header("x-ratelimit-remaining", to_string(remaining))
+        |> put_rate_limit_headers(limit, scale, remaining)
         |> decorate_fun.(response)
 
       {:error, :rate_limited} ->
+        remaining = @limiter.remaining(%ExLimiter.Bucket{key: bucket_name}, scale: scale, limit: limit)
+
         conn
+        |> put_rate_limit_headers(limit, scale, remaining)
         |> decorate_fun.({:rate_limited, bucket_name})
         |> fallback.render_error(:rate_limited)
     end
+  end
+
+  defp put_rate_limit_headers(conn, limit, scale, remaining) do
+    conn
+    |> put_resp_header("x-ratelimit-limit", to_string(limit))
+    |> put_resp_header("x-ratelimit-window", to_string(scale))
+    |> put_resp_header("x-ratelimit-remaining", to_string(remaining))
   end
 
   defp ip(conn), do: conn.remote_ip |> Tuple.to_list() |> Enum.join(".")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLimiter.Mixfile do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.5.0"
 
   def project do
     [

--- a/test/ex_limiter/plug_test.exs
+++ b/test/ex_limiter/plug_test.exs
@@ -1,6 +1,7 @@
 defmodule ExLimiter.PlugTest do
   use ExUnit.Case
   use Plug.Test
+
   alias ExLimiter.TestUtils
 
   describe "#call/2" do
@@ -65,14 +66,17 @@ defmodule ExLimiter.PlugTest do
   defp decorate(conn, {:ok, %{key: bucket_name, version: bucket_version}}) do
     assign(conn, :ex_limiter, %{bucket_name: bucket_name, bucket_version: bucket_version})
   end
+
   defp decorate(conn, {:rate_limited, bucket_name}) do
     assign(conn, :ex_limiter, %{bucket_name: bucket_name})
   end
 
   defp setup_conn(_) do
-    random =  TestUtils.rand_string()
+    random = TestUtils.rand_string()
+
     conn =
-      conn(:get, "/")
+      :get
+      |> conn("/")
       |> merge_private(phoenix_controller: random, phoenix_action: random)
 
     [conn: conn]

--- a/test/ex_limiter/plug_test.exs
+++ b/test/ex_limiter/plug_test.exs
@@ -20,6 +20,10 @@ defmodule ExLimiter.PlugTest do
          |> ExLimiter.Plug.call(config)
 
       assert conn.status == 429
+
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-limit"))
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-window"))
+      refute Enum.empty?(get_resp_header(conn, "x-ratelimit-remaining"))
     end
 
     test "it will respect scaling params", %{limiter: config, conn: conn} do


### PR DESCRIPTION
## What this does

This PR updates the `{:error, :rate_limited}` path in `ExLimiter.Plug.call/2` so that rate limit headers (`x-ratelimit-limit`, `x-ratelimit-scale`, `x-ratelimit-remaining`) are returned in the event of a `429` scenario. 

This PR also updates the unit test for such a rate limiting scenario to assert the presence of these headers.

## Why do this?
This is a commonly requested feature within the Frame organization and it is overall helpful for callers to know precisely how long to wait before they can try again without being rate limited.

## Alternatives investigated
### Exception path
One alternative could involve creating a `RateLimitError` exception struct that could carry a bucket and would be returned. This would require updating any callers of `leak_and_consume` to provide a boundary function that could return such an exception -- a very wide surface area and these functions are potentially implemented by consumers of this library. This would also require adding another clause to the `case` statement in the `Plug` to catch `{:error, %RateLimitError{}` cases and do the necessary header population.

### Expose `fetch/1` in `ExLimiter.Base`
Get ExLimiter.Base to expose a `fetch/1` function that would simply delegate down to the storage implementation's `fetch/1` function. This is virtually the same solution as what is proposed here, only with more ceremony and enlarging the API of this library.

## Motivational Imagery
![On the hunt for the missing headers](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWc3NmhscmlpM3ZkamNwbmcyaXRkZGk0ajJ4b2tld2E2MzVycW1xcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FlQQRZL4N3N64EXzHd/giphy.gif)
_On the hunt for missing headers_